### PR TITLE
Allow fine-tuning of MyST, Docutils and Sphinx settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `MYST_DOCUTILS_SETTINGS` and `MYST_SPHINX_SETTINGS` to configure each renderer and MyST parser.
+- Documents the new configuration settings.
+- Adds typing to some methods.
+
 ### Changed
 
-- Upgrade to myst-parser v2.
+- Upgrade to myst-parser v2.0.0.
+- Cleans up the merge of users and default settings.
+
+### Deprecated
+
+- Deprecates `MYST_EXTENSIONS` settings.
+- Feed `MYST_EXTENSIONS` to `MYST_DOCUTILS_SETTINGS` and `MYST_SPHINX_SETTINGS` in the mean time.
+
+### Fixed
+
+- Forces initial header level to `<h2>` instead of `<h1>`, since Pelican will use the title field in the front-matter as the `<h1>` header of the page.
 
 ## [1.2.0b1] - 2022-10-26
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MyST Reader: A Plugin for Pelican
 
-[![Build Status](https://img.shields.io/github/workflow/status/ashwinvis/myst-reader/build)](https://github.com/ashwinvis/myst-reader/actions)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/ashwinvis/myst-reader/build.yaml?branch=main)](https://github.com/ashwinvis/myst-reader/actions)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/ashwinvis/myst-reader/main.svg)](https://results.pre-commit.ci/latest/github/ashwinvis/myst-reader/main)
 [![PyPI Version](https://img.shields.io/pypi/v/pelican-myst-reader)](https://pypi.org/project/pelican-myst-reader/)
 ![License](https://img.shields.io/pypi/l/pelican-myst-reader?color=blue)
@@ -23,7 +23,7 @@ python -m pip install pelican-myst-reader
 
 As soon as the plugin is installed, it will automatically be used by Pelican to parse and render all Markdown files with the MyST syntax.
 
-## Writting MyST content
+## Writing MyST content
 
 MyST syntax is a superset of [CommonMark][]. So if you feed your Pelican site with
 non-MyST Markdown files or other variants, most of them will probably renders as they were with this plugin.

--- a/pelican/plugins/myst_reader/_docutils_renderer.py
+++ b/pelican/plugins/myst_reader/_docutils_renderer.py
@@ -1,22 +1,26 @@
+"""Implementation of a Docutils-based renderer for MyST documents.
+
+See Docutils docs at: https://docutils.sourceforge.io
+"""
+
 from __future__ import annotations
+
+from typing import Any
 
 from docutils.core import publish_parts
 from myst_parser.docutils_ import Parser
 
 
-def myst2html(
-    source: str,
-    myst_extensions: tuple[str],
+def docutils_renderer(
+    content: str,
+    conf: dict[str, Any],
     parser: Parser,
 ):
-    """Public API in https://myst-parser.readthedocs.io/en/v0.18.0/docutils.html"""
+    """Use the HTML5 writer: https://docutils.sourceforge.io/docs/user/config.html#html5-writer"""
     parts = publish_parts(
-        source=source,
+        source=content,
         writer_name="html5",
-        settings_overrides={
-            "myst_enable_extensions": myst_extensions,
-            "embed_stylesheet": False,
-        },
+        settings_overrides=conf,
         parser=parser,
     )
     output = parts["body"]

--- a/pelican/plugins/myst_reader/exceptions.py
+++ b/pelican/plugins/myst_reader/exceptions.py
@@ -1,0 +1,2 @@
+class MystReaderContentError(ValueError):
+    """Content related issues detected by Myst reader plugin."""

--- a/tests/test_cases_valid.py
+++ b/tests/test_cases_valid.py
@@ -142,7 +142,8 @@ def test_comments(strip_comments):
     assert "My Author" == str(metadata["author"])
     assert "2020-10-16 00:00:00" == str(metadata["date"])
 
-    assert "standalone comment" in output is not strip_comments
+    expected_comment = not strip_comments
+    assert ("standalone comment" in output) is expected_comment
 
 
 def test_links():

--- a/tests/test_content/expected/valid_content_comments_strip_comments=False.html
+++ b/tests/test_content/expected/valid_content_comments_strip_comments=False.html
@@ -1,0 +1,3 @@
+<p>This is file contains</p>
+<!-- standalone comment -->
+<p>a comment which may or may not be stripped.</p>

--- a/tests/test_content/expected/valid_content_comments_strip_comments=True.html
+++ b/tests/test_content/expected/valid_content_comments_strip_comments=True.html
@@ -1,0 +1,2 @@
+<p>This is file contains</p>
+<p>a comment which may or may not be stripped.</p>

--- a/tests/test_content/valid_content_comments.md
+++ b/tests/test_content/valid_content_comments.md
@@ -1,0 +1,8 @@
+---
+title: Valid Content with Comments
+author: My Author
+date: 2020-10-16
+---
+This is file contains
+% standalone comment
+a comment which may or may not be stripped.

--- a/tests/test_invalid_metadata.py
+++ b/tests/test_invalid_metadata.py
@@ -3,6 +3,7 @@ import os
 import unittest
 
 from pelican.plugins.myst_reader import MySTReader
+from pelican.plugins.myst_reader.exceptions import MystReaderContentError
 from pelican.tests.support import get_settings
 
 DIR_PATH = os.path.dirname(__file__)
@@ -36,9 +37,7 @@ class TestInvalidMetadata(unittest.TestCase):
         myst_reader = MySTReader(settings)
 
         msg1 = "Could not find front-matter metadata or invalid formatting."
-        msg2 = (
-            "<string>:1: (ERROR/3) Document or section may not begin with a transition."
-        )
+        msg2 = "Malformed content or front-matter metadata"
 
         for source_md, expected_msg in (
             ("no_metadata.md", msg1),
@@ -49,7 +48,7 @@ class TestInvalidMetadata(unittest.TestCase):
             source_path = os.path.join(TEST_CONTENT_PATH, source_md)
 
             # If the file is not empty but has no metadata it should fail
-            with self.assertRaises(Exception) as context_manager:
+            with self.assertRaises(MystReaderContentError) as context_manager:
                 myst_reader.read(source_path)
 
             message = str(context_manager.exception)

--- a/tests/test_invalid_metadata.py
+++ b/tests/test_invalid_metadata.py
@@ -35,11 +35,16 @@ class TestInvalidMetadata(unittest.TestCase):
 
         myst_reader = MySTReader(settings)
 
-        for source_md in (
-            "no_metadata.md",
-            "metadata_start_with_leading_spaces.md",
-            "metadata_end_with_leading_spaces.md",
-            "no_metadata_end.md",
+        msg1 = "Could not find front-matter metadata or invalid formatting."
+        msg2 = (
+            "<string>:1: (ERROR/3) Document or section may not begin with a transition."
+        )
+
+        for source_md, expected_msg in (
+            ("no_metadata.md", msg1),
+            ("metadata_start_with_leading_spaces.md", msg1),
+            ("metadata_end_with_leading_spaces.md", msg2),
+            ("no_metadata_end.md", msg2),
         ):
             source_path = os.path.join(TEST_CONTENT_PATH, source_md)
 
@@ -48,6 +53,4 @@ class TestInvalidMetadata(unittest.TestCase):
                 myst_reader.read(source_path)
 
             message = str(context_manager.exception)
-            self.assertEqual(
-                "Could not find front-matter metadata or invalid formatting.", message
-            )
+            self.assertEqual(expected_msg, message)


### PR DESCRIPTION
This PR:

- Adds a new `MYST_DOCUTILS_SETTINGS` and `MYST_SPHINX_SETTINGS` to configure each renderer and MyST parser
- Deprecates `MYST_EXTENSIONS`
- Feed `MYST_EXTENSIONS` to `MYST_DOCUTILS_SETTINGS` and `MYST_SPHINX_SETTINGS` in the mean time
- Forces initial header level to `<h2>` instead of `<h1>`, since Pelican will use the title field in the front-matter as the `<h1>` header of the page
- Adds typing to methods
- Cleans up the merge of users and default settings
- Documents the new configuration settings

Thanks to this PR, the behaviour of MyST parsing can be highly fine-tuned, which will invite users to more exploration.